### PR TITLE
Update cgt from 2.2git to 2.2dev

### DIFF
--- a/var/spack/repos/builtin/packages/cgt/package.py
+++ b/var/spack/repos/builtin/packages/cgt/package.py
@@ -8,9 +8,9 @@ class Cgt(AutotoolsPackage):
     """NASA CGT"""
 
     homepage = "https://www.nas.nasa.gov/software/chimera.html"
-    url = "file:///aerolab/admin/software/dist/cgt/chimera2.2git.tar.gz"
+    url = "file:///auto/admin/software/dist/cgt/chimera2.2dev.tar.gz"
 
-    version("2.2git", sha256="e5133b23af83d619ae99cb191539f2f62e88ddfb749a72a4f10fac294cf78597")
+    version("2.2dev", sha256="091bf927637a671eb6def1a4be044f498349ce4478e82c0ea1aec26eff531af5")
 
     variant("dp",    default=False, description="Enable double precision.")
     variant("oggui", default=True, description="Build Overgrid GUI.")

--- a/var/spack/repos/builtin/packages/chem/package.py
+++ b/var/spack/repos/builtin/packages/chem/package.py
@@ -4,9 +4,8 @@ class Chem(AutotoolsPackage):
     """MSU Chem"""
 
     homepage = "https://web.cse.msstate.edu/~luke/loci"
-    url = "file:///aerolab/admin/software/dist/chem/chem-4.0-p6a.tgz"
+    url = "file:///auto/admin/software/dist/chem/chem-4.0-p6a.tgz"
 
-    version("4.0-p5", sha256="47b67e7069fd7dc970025612533c4183ac5f8addfe653a96ff7ac4c8a45840f2")
     version("4.0-p6a", sha256="f5137523c06a591f7b0381f293b2bcb052c8803b04fcfcb1349db1592ff524c8")
 
     patch('chem_jsc_d.patch')

--- a/var/spack/repos/builtin/packages/fun3d/package.py
+++ b/var/spack/repos/builtin/packages/fun3d/package.py
@@ -11,7 +11,7 @@ class Fun3d(AutotoolsPackage):
     """NASA's FUN3D CFD Solver"""
 
     homepage = "https://fun3d.larc.nasa.gov/"
-    url = "file:///aerolab/admin/software/dist/fun3d/fun3d_intg-14.0d03712b.tar.gz"
+    url = "file:///auto/admin/software/dist/fun3d/fun3d_intg-14.0d03712b.tar.gz"
 
     version("14.0d03712b", sha256="d92cdb39994771389effe99f783fe72094481d6d114518593070017def27c4ac")
 

--- a/var/spack/repos/builtin/packages/loci/package.py
+++ b/var/spack/repos/builtin/packages/loci/package.py
@@ -4,7 +4,7 @@ class Loci(AutotoolsPackage):
     """Logic Programming for Parallel Computational Field Simulations"""
 
     homepage = "https://web.cse.msstate.edu/~luke/loci"
-    url = "file:///aerolab/admin/software/dist/loci/Loci-4.0-p5.tgz"
+    url = "file:///auto/admin/software/dist/loci/Loci-4.0-p5.tgz"
 
     version("4.0-p5",  sha256="47b67e7069fd7dc970025612533c4183ac5f8addfe653a96ff7ac4c8a45840f2")
 

--- a/var/spack/repos/builtin/packages/overflow/package.py
+++ b/var/spack/repos/builtin/packages/overflow/package.py
@@ -17,7 +17,7 @@ class Overflow(CMakePackage):
 
 
     homepage = "https://overflow.larc.nasa.gov"
-    url = "file:///aerolab/admin/software/dist/overflow/over2.4c.tar.gz"
+    url = "file:///auto/admin/software/dist/overflow/over2.4c.tar.gz"
 
     version("2.4b", sha256="89ba0302477726ca5a49154bb4c50e96ce4c23ec2901f7b03d24e5a197566021")
     version("2.4c", sha256="a2fe09924817a408649c60c613a5eb7a655b454a91e6248a2fd6098b44b7dec3")

--- a/var/spack/repos/builtin/packages/pegasus/package.py
+++ b/var/spack/repos/builtin/packages/pegasus/package.py
@@ -29,7 +29,7 @@ class Pegasus(Package):
     inside a solid body."""
 
     homepage = "https://www.nas.nasa.gov/publications/software/docs/pegasus5/pages/sec1.html"
-    url = "file:///aerolab/admin/software/dist/pegasus/pegasus5.2d.tar.gz"
+    url = "file:///auto/admin/software/dist/pegasus/pegasus5.2d.tar.gz"
 
     # notify when the package is updated.
     # maintainers("github_user1", "github_user2")

--- a/var/spack/repos/builtin/packages/tecio/package.py
+++ b/var/spack/repos/builtin/packages/tecio/package.py
@@ -14,14 +14,13 @@ class Tecio(CMakePackage):
 
     homepage = "https://www.tecplot.com/products/tecio-library/"
     #url = "file://{}/tecio.tgz".format(os.getcwd())
-    url = "file:///aerolab/admin/software/dist/tecplot/tecio.2023.1.1.tgz"
+    url = "file:///auto/admin/software/dist/tecplot/tecio.2023.1.1.tgz"
 
     manual_download = True
 
     maintainers("snehring")
 
     version("2023.1.1", sha256="1468430e3cf6f019175da2559e63c5d6cf61c8569a3e994890448d1c6f7aa1f3")
-
 
     #depends_on("cmake@3.0.2:", type="build")
 


### PR DESCRIPTION
Darby asked me to change the version of cgt from 2.2git to 2.2dev.

I noticed the file path was using the deprecated "aerolab" instead of "auto" 

I found 6 other instances of other packages that were using the wrong path so I updated them as well.

Please review for errors or problems.
